### PR TITLE
deb packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - checkout
 
+      - run: apt-get install ruby ruby-dev rubygems build-essential
+      - run: gem install --no-ri --no-rdoc fpm
+
       - run: go get github.com/golang/dep/cmd/dep
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - checkout
 
       - run: sudo apt-get install ruby ruby-dev rubygems build-essential
-      - run: gem install --no-ri --no-rdoc fpm
+      - run: sudo gem install --no-ri --no-rdoc fpm
 
       - run: go get github.com/golang/dep/cmd/dep
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - checkout
 
-      - run: apt-get install ruby ruby-dev rubygems build-essential
+      - run: sudo apt-get install ruby ruby-dev rubygems build-essential
       - run: gem install --no-ri --no-rdoc fpm
 
       - run: go get github.com/golang/dep/cmd/dep

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ fpm:
   vendor: Dom Udall
   homepage: https://domudall.co.uk/
   maintainer: Dom Udall <me@domudall.co.uk>
-  description: TODO
+  description: Tool for shutting down/starting up Google Cloud Engine instances based on tags for savings costs when not in use.
   license: MIT
   formats:
     - deb

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,3 +5,14 @@ builds:
       - linux
     goarch:
       - amd64
+
+fpm:
+  vendor: Dom Udall
+  homepage: https://domudall.co.uk/
+  maintainer: Dom Udall <me@domudall.co.uk>
+  description: TODO
+  license: MIT
+  formats:
+    - deb
+  files:
+    "deb/etc/gce-sleep.conf": "/etc/gce-sleep.conf"

--- a/deb/etc/gce-sleep.conf
+++ b/deb/etc/gce-sleep.conf
@@ -1,0 +1,20 @@
+project "default" {
+    zones = [
+        "europe-west1-b",
+        "europe-west1-c",
+        "europe-west1-d"
+    ]
+}
+
+ruleset "weekly-sleep" {
+    startTime = "06:00"
+    stopTime = "20:00"
+    timezone = "Europe/London"
+    days = [
+        1,
+        2,
+        3,
+        4,
+        5
+    ]
+}


### PR DESCRIPTION
Adds `deb` package to `goreleaser` to allow for installation with apt. Uses [fpm](https://github.com/jordansissel/fpm) installed in CircleCI for publishing on Github tag push.